### PR TITLE
Make github.io README links more prominent

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@
 A simple [ClojureScript](http://github.com/clojure/clojurescript) interface to
 [React](http://facebook.github.io/react/).
 
-[Reagent](http://holmsand.github.io/reagent/) provides a way to write efficient
-React components using (almost) nothing but plain ClojureScript functions.
+Reagent provides a way to write efficient React components using (almost) nothing but plain ClojureScript functions.
+
+  * **[Detailed intro with live examples](http://holmsand.github.io/reagent/)**
+  * **[News](http://holmsand.github.io/reagent/news/index.html)**
 
 To use Reagent you add this to your dependencies in `project.clj`:
 


### PR DESCRIPTION
You've got a great github.io page but it's not at all clear from the current README. Would suggest bringing more attention to it.
