### PR TITLE
Make multimethods work as component functions.

### DIFF
--- a/src/reagent/impl/component.cljs
+++ b/src/reagent/impl/component.cljs
@@ -35,7 +35,7 @@
 (defn do-render [C]
   (binding [*current-component* C]
     (let [f (aget C cljs-render)
-          _ (assert (ifn? f))
+          _ (assert (util/clj-ifn? f))
           p (util/js-props C)
           res (if (nil? (aget C "componentFunction"))
                 (f C)
@@ -155,7 +155,7 @@
 (defn wrap-funs [fun-map]
   (let [render-fun (or (:componentFunction fun-map)
                        (:render fun-map))
-        _ (assert (ifn? render-fun)
+        _ (assert (util/clj-ifn? render-fun)
                   (str "Render must be a function, not "
                        (pr-str render-fun)))
         name (or (:displayName fun-map)

--- a/src/reagent/impl/template.cljs
+++ b/src/reagent/impl/template.cljs
@@ -29,7 +29,7 @@
 
 (defn valid-tag? [x]
   (or (hiccup-tag? x)
-      (ifn? x)))
+      (util/clj-ifn? x)))
 
 (defn map-into-array [f arg coll]
   (let [a (into-array coll)]

--- a/src/reagent/impl/util.cljs
+++ b/src/reagent/impl/util.cljs
@@ -70,6 +70,13 @@
   IHash
   (-hash [_] (hash [f args])))
 
+; patch for CLJS-777; Can be replaced with clojure.core/ifn? after updating
+; ClojureScript to a version that includes the fix:
+; https://github.com/clojure/clojurescript/commit/525154f2a4874cf3b88ac3d5755794de425a94cb
+(defn clj-ifn? [x]
+  (or (ifn? x)
+      (satisfies? IMultiFn x)))
+
 (defn- merge-class [p1 p2]
   (let [class (when-let [c1 (:class p1)]
                 (when-let [c2 (:class p2)]

--- a/test/testcloact.cljs
+++ b/test/testcloact.cljs
@@ -282,12 +282,18 @@
       "Dynamic id overwrites static"))
 
 (deftest ifn-component []
+  (defmulti my-div :type)
+  (defmethod my-div :fooish [child] [:div.foo (:content child)])
+  (defmethod my-div :barish [child] [:div.bar (:content child)])
+
   (let [comp {:foo [:div "foodiv"]
               :bar [:div "bardiv"]}]
     (is (re-find #"foodiv"
                  (as-string [:div [comp :foo]])))
     (is (re-find #"bardiv"
-                 (as-string [:div [comp :bar]])))))
+                 (as-string [:div [comp :bar]])))
+    (is (re-find #"class=.foo"
+                 (as-string [my-div {:type :fooish :content "inner"}])))))
 
 (deftest symbol-string-tag []
   (is (re-find #"foobar"


### PR DESCRIPTION
This is actually a [bug](http://dev.clojure.org/jira/browse/CLJS-777) in ClojureScript.  In regular Clojure a `MultiFn` is `ifn?`, but in ClojureScript it wasn't.  The bug is fixed in clojure/clojurescript@525154f2a4874cf3b88ac3d5755794de425a94cb but not yet released.

This code can be reverted after Reagent's ClojureScript version is updated.

There are a few more checks whether functions are `ifn?` in src/reagent/impl/component.cljs and src/reagent/impl/template.cljs.  I only changed the ones necessary to get my test passing.  Do you think those others should be changed too?  Let me know and I'll push an update to this branch.
