### PR TITLE
Update simpleexample.cljs

### DIFF
--- a/examples/simple/src/simpleexample.cljs
+++ b/examples/simple/src/simpleexample.cljs
@@ -1,4 +1,3 @@
-
 (ns simpleexample
   (:require [reagent.core :as reagent :refer [atom]]))
 
@@ -33,5 +32,5 @@
    [color-input]])
 
 (defn ^:export run []
-  (reagent/render-component (fn [] [simple-example])
+  (reagent/render-component [simple-example]
                             (.-body js/document)))


### PR DESCRIPTION
Fixes `has no method 'mountComponentIntoNode'` error
