### PR TITLE
Fixed syntax to conform to latest Reagent version

### DIFF
--- a/examples/simple/src/simpleexample.cljs
+++ b/examples/simple/src/simpleexample.cljs
@@ -33,5 +33,5 @@
    [color-input]])
 
 (defn ^:export run []
-  (reagent/render-component (fn [] [simple-example])
+  (reagent/render-component [simple-example]
                             (.-body js/document)))


### PR DESCRIPTION
Apparently I should submit this here after all. IMO it's a change worth making. I tried this as my first ever Reagent program and it was bewildering (and discouraging) to have it fail with a cryptic error message.
