### PR TITLE
add react-with-addons versions to jar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,10 @@ download-react:
 		-o vendor/reagent/react.js
 	curl -L "http://fb.me/react-$(REACT_VERSION).min.js" \
 		-o vendor/reagent/react.min.js
+	curl -L "http://fb.me/react-with-addons-$(REACT_VERSION).js" \
+		-o vendor/reagent/react-with-addons.js
+	curl -L "http://fb.me/react-with-addons-$(REACT_VERSION).min.js" \
+		-o vendor/reagent/react-with-addons.min.js
 
 VERSION := `sed -n -e '/(defproject reagent/ s/.*"\(.*\)"/\1/p' project.clj`
 


### PR DESCRIPTION
The react-with-addons files include the useful TestUtils framework React uses, among other things. It would be useful to bundle this up and allow reagent to provide access to that out-of-the-box, at a cost of just two more curl requests. What do you think?