### PR TITLE
Remove recursive link in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 
 A simple [ClojureScript](http://github.com/clojure/clojurescript) interface to [React](http://facebook.github.io/react/).
 
-The main repository for Reagent is now located [here](https://github.com/reagent-project/reagent).
-
 Reagent provides a way to write efficient React components using (almost) nothing but plain ClojureScript functions.
 
   * **[Detailed intro with live examples](http://reagent-project.github.io/)**


### PR DESCRIPTION
There was a link in the README.md that indicated the reagent repo had moved, but the link pointed back to this exact project. Removed it.