### PR TITLE
require reagent.ratom macros in cljs namespace

### DIFF
--- a/src/reagent/ratom.cljs
+++ b/src/reagent/ratom.cljs
@@ -1,6 +1,7 @@
 (ns reagent.ratom
   (:refer-clojure :exclude [atom])
-  (:require-macros [reagent.debug :refer (dbg log warn dev?)])
+  (:require-macros [reagent.debug :refer (dbg log warn dev?)]
+                   reagent.ratom)
   (:require [reagent.impl.util :as util]))
 
 (declare ^:dynamic *ratom-context*)


### PR DESCRIPTION
Quoting [Clojurescript 0.0-2755 release notes](https://groups.google.com/forum/#!topic/clojurescript/FoiqNV5nunQ):

> The first [improvement] is around macros. If your library does the following:

    (ns foo.bar
       (:require-macros foo.bar))

> Then users that require your library:

    (ns bar.baz
      (:require [foo.bar :as foo]))

> Will get  `foo.bar` macros automatically required and aliased to `foo`.

I think it would be a useful convention to require macros of respective Clojure namespaces. Is there a reason I might be not aware of that this hasn't been done? I'm new to Reagent :-)