### PR TITLE
Reaction equality

### DIFF
--- a/src/reagent/ratom.cljs
+++ b/src/reagent/ratom.cljs
@@ -241,7 +241,7 @@
 
   IComputedImpl
   (-handle-change [this sender oldval newval]
-    (when (and active? (not (identical? oldval newval)))
+    (when (and active? (not= oldval newval))
       (set! dirty? true)
       ((or auto-run run) this)))
 
@@ -287,7 +287,7 @@
         (when dirty?
           (let [oldstate state]
             (set! state (f))
-            (when-not (identical? oldstate state)
+            (when-not (= oldstate state)
               (-notify-watches this oldstate state))))
         state)))
 
@@ -396,4 +396,3 @@
   (Wrapper. value
             (util/partial-ifn. callback-fn args nil)
             false nil))
-

--- a/test/reagenttest/testratom.cljs
+++ b/test/reagenttest/testratom.cljs
@@ -81,8 +81,8 @@
       (dispose co))
     (let [!x (rv/atom 0)
           !co (rv/make-reaction #(inc @!x) :auto-run true)]
-      (is (= 1 @!co) "CO has correct value on first deref") 
-      (swap! !x inc) 
+      (is (= 1 @!co) "CO has correct value on first deref")
+      (swap! !x inc)
       (is (= 2 @!co) "CO auto-updates")
       (dispose !co))
     (is (= runs (running)))))
@@ -107,27 +107,27 @@
       (is (= @res (+ 2 @a)))
       (is (= @b-changed 1))
       (is (= @c-changed 0))
-             
+
       (reset! a -1)
       (is (= @res (+ 2 @a)))
       (is (= @b-changed 2))
       (is (= @c-changed 0))
-             
+
       (reset! a 2)
       (is (= @res (+ 10 @a)))
       (is (<= 2 @b-changed 3))
       (is (= @c-changed 1))
-             
+
       (reset! a 3)
       (is (= @res (+ 10 @a)))
       (is (<= 2 @b-changed 3))
       (is (= @c-changed 2))
-             
+
       (reset! a 3)
       (is (= @res (+ 10 @a)))
       (is (<= 2 @b-changed 3))
       (is (= @c-changed 2))
-             
+
       (reset! a -1)
       (is (= @res (+ 2 @a)))
       (dispose res)
@@ -237,6 +237,17 @@
     (reset! a 1)
     (is (= @b 6))
     (is (= runs (running)))))
+
+(deftest reaction-equality
+  (let [count (atom 0)
+        a (rv/atom {:foo {:bar "baz"}})
+        r (rv/reaction (:foo @a))]
+    (run!
+     (is (= @r {:bar "baz"}))
+     (swap! count inc))
+    (swap! a assoc-in [:foo :bar] "baz")
+    (swap! a assoc :foo {:bar "baz"})
+    (is (= @count 1))))
 
 ;; (deftest catching
 ;;   (let [runs (running)

--- a/test/reagenttest/testwrap.cljs
+++ b/test/reagenttest/testwrap.cljs
@@ -45,7 +45,7 @@
       (is (= @w1 @w2))
       (is (not= w1 w2))
       (reset! w1 1))
-    
+
     (let [w1 (ws) w2 (ws)]
       (is (= @w1 1))
       (is (= w1 w2))
@@ -161,18 +161,18 @@
           (reset! @grand-state {:foobar 2})
           (r/flush)
           (is (found-in #"value:2:" div))
-          (is (= @ran 5))
+          (is (= @ran 4))
 
           (reset! state {:foo {:bar {:foobar 4}}})
           (reset! @grand-state {:foobar 4})
           (r/flush)
           (is (found-in #"value:4:" div))
-          (is (= @ran 6))
+          (is (= @ran 5))
 
           (reset! @grand-state {:foobar 4})
           (r/flush)
           (is (found-in #"value:4:" div))
-          (is (= @ran 7)))))))
+          (is (= @ran 5)))))))
 
 (deftest test-cursor
  (let [state (atom {:a 0


### PR DESCRIPTION
I was running into a scenario where a reaction was running when I did not expect it to.  Here's a minimal example demonstrating the issue:

```clojure
(def db (reagent/atom {:foo ["test"]
                       :bar ["hello" "world"]}))

(def bar (reaction (map upper-case (:bar @db))))

(run! (print "bar changed:" @bar))

(defn update-foo [val]
  (swap! db assoc :foo [val]))
```

In this case, running `(update-foo "test")` was causing "bar changed" to be printed to the console.  By switching `identical?` to `=` the behavior became more intuitive and and the reaction was only run when the value was not `=` to the previous value.

Is there a reason that `identical?` is being used?  I think this change will even improve performance since components will need to be re-rendered less.