### PR TITLE
Make use of deftype constructor instead of interop

### DIFF
--- a/src/reagent/impl/batching.cljs
+++ b/src/reagent/impl/batching.cljs
@@ -63,7 +63,7 @@
       (run-queue q)
       (run-funs aq))))
 
-(def render-queue (RenderQueue. (array) false (array)))
+(def render-queue (->RenderQueue (array) false (array)))
 
 (defn flush []
   (.run-queue render-queue))

--- a/src/reagent/impl/template.cljs
+++ b/src/reagent/impl/template.cljs
@@ -193,9 +193,9 @@
     (.' js/React createElement c jsprops)))
 
 (defn adapt-react-class [c]
-  (NativeWrapper. #js{:name c
-                      :id nil
-                      :class nil}))
+  (->NativeWrapper #js{:name c
+                       :id nil
+                       :class nil}))
 
 (def tag-name-cache #js{})
 

--- a/src/reagent/ratom.cljs
+++ b/src/reagent/ratom.cljs
@@ -2,7 +2,7 @@
   (:refer-clojure :exclude [atom])
   (:require-macros [reagent.debug :refer (dbg log warn dev?)]
                    reagent.ratom)
-  (:require [reagent.impl.util :as util]))
+  (:require [reagent.impl.util :as util :refer [->partial-ifn]]))
 
 (declare ^:dynamic *ratom-context*)
 
@@ -92,8 +92,8 @@
 
 (defn atom
   "Like clojure.core/atom, except that it keeps track of derefs."
-  ([x] (RAtom. x nil nil nil))
-  ([x & {:keys [meta validator]}] (RAtom. x meta validator nil)))
+  ([x] (->RAtom x nil nil nil))
+  ([x & {:keys [meta validator]}] (->RAtom x meta validator nil)))
 
 
 
@@ -173,14 +173,14 @@
       (assert (satisfies? IReactiveAtom path)
               (str "src must be a reactive atom, not "
                    (pr-str path)))
-      (RCursor. path src nil))
+      (->RCursor path src nil))
     (do
       (assert (or (satisfies? IReactiveAtom src)
                   (and (ifn? src)
                        (not (vector? src))))
               (str "src must be a reactive atom or a function, not "
                    (pr-str src)))
-      (RCursor. src path nil))))
+      (->RCursor src path nil))))
 
 
 
@@ -320,9 +320,9 @@
   (let [runner (if (= auto-run true) run auto-run)
         active (not (nil? derefed))
         dirty (not active)
-        reaction (Reaction. f nil dirty active
-                            nil nil
-                            runner on-set on-dispose)]
+        reaction (->Reaction f nil dirty active
+                             nil nil
+                             runner on-set on-dispose)]
     (when-not (nil? derefed)
       (when debug (swap! -running inc))
       (-update-watching reaction derefed))
@@ -393,7 +393,7 @@
     (-write writer ">")))
 
 (defn make-wrapper [value callback-fn args]
-  (Wrapper. value
-            (util/partial-ifn. callback-fn args nil)
-            false nil))
+  (->Wrapper value
+             (->partial-ifn callback-fn args nil)
+             false nil))
 


### PR DESCRIPTION
As Stuart Sierra stated in his [blog post](http://stuartsierra.com/2015/05/17/clojure-record-constructors)
we should use `deftype` and `defrecord` constructor functions or create
our own constructor functions for types and records.
