### PR TITLE
Revert #128 and add tests for ISwap implementations

### DIFF
--- a/src/reagent/ratom.cljs
+++ b/src/reagent/ratom.cljs
@@ -64,7 +64,7 @@
     (-reset! a (f state x)))
   (-swap! [a f x y]
     (-reset! a (f state x y)))
-  (-swap! [a f x y & more]
+  (-swap! [a f x y more]
     (-reset! a (apply f state x y more)))
 
   IMeta
@@ -143,7 +143,7 @@
     (-swap! (._reaction a) f x))
   (-swap! [a f x y]
     (-swap! (._reaction a) f x y))
-  (-swap! [a f x y & more]
+  (-swap! [a f x y more]
     (-swap! (._reaction a) f x y more))
 
   IPrintWithWriter
@@ -236,7 +236,7 @@
     (-reset! a (f (-peek-at a) x)))
   (-swap! [a f x y]
     (-reset! a (f (-peek-at a) x y)))
-  (-swap! [a f x y & more]
+  (-swap! [a f x y more]
     (-reset! a (apply f (-peek-at a) x y more)))
 
   IComputedImpl
@@ -362,7 +362,7 @@
     (-reset! a (f state x)))
   (-swap! [a f x y]
     (-reset! a (f state x y)))
-  (-swap! [a f x y & more]
+  (-swap! [a f x y more]
     (-reset! a (apply f state x y more)))
 
   IEquiv

--- a/test/reagenttest/testcursor.cljs
+++ b/test/reagenttest/testcursor.cljs
@@ -336,6 +336,12 @@
     (is (= (get-in @test-atom [])
            {:z 3}))
 
+    (reset! test-cursor {}) ;; empty map
+    (swap! test-cursor assoc :x 1 :y 2 :z 3 :w)
+    (is (= @test-cursor {:x 1 :y 2 :z 3 :w nil}))
+    (is (= (get-in @test-atom [:a :b :c :d])
+           {:x 1 :y 2 :z 3 :w nil}))
+
     (is (= runs (running)))))
 
 

--- a/test/reagenttest/testwrap.cljs
+++ b/test/reagenttest/testwrap.cljs
@@ -105,6 +105,8 @@
     (is (= (swap! a update-in [:k] inc)
            (swap! b update-in [:k] inc)))
     (is (= @a @b {:k 2}))
+    (is (= (swap! a assoc :k 3 :l 4 :m 7 :n 8 :o)
+           (swap! b assoc :k 3 :l 4 :m 7 :n 8 :o)))
     (is (= (reset! a 23)
            (reset! b 23)))
     (is (= @a @b))


### PR DESCRIPTION
I'm not sure what the motivation behind #128 was, as the & syntax doesn't work with deftype and the core swap! function does this destructuring already. I added some tests for the old ISwap implementations, and they seem to work as expected.
