### PR TITLE
Support component getChildContext and childContextTypes

### DIFF
--- a/src/reagent/core.cljs
+++ b/src/reagent/core.cljs
@@ -109,14 +109,16 @@ Returns the mounted component instance."
   "Create a component, React style. Should be called with a map,
 looking like this:
 {:get-initial-state (fn [this])
-:component-will-receive-props (fn [this new-argv])
-:should-component-update (fn [this old-argv new-argv])
-:component-will-mount (fn [this])
-:component-did-mount (fn [this])
-:component-will-update (fn [this new-argv])
-:component-did-update (fn [this old-argv])
-:component-will-unmount (fn [this])
-:reagent-render (fn [args....])   ;; or :render (fn [this])
+ :get-child-context (fn [this])
+ :child-context-types {:key type}
+ :component-will-receive-props (fn [this new-argv])
+ :should-component-update (fn [this old-argv new-argv])
+ :component-will-mount (fn [this])
+ :component-did-mount (fn [this])
+ :component-will-update (fn [this new-argv])
+ :component-did-update (fn [this old-argv])
+ :component-will-unmount (fn [this])
+ :reagent-render (fn [args....])   ;; or :render (fn [this])
 }
 
 Everything is optional, except either :reagent-render or :render.


### PR DESCRIPTION
This adds basic support for the experimental "Context" feature of react.js.

https://www.tildedave.com/2014/11/15/introduction-to-contexts-in-react-js.html

It adds two properties to reagent.core/create-class:

:child-context-types {:key type}, a dictionary specifying the types of objects returnable by the component's context,
:get-child-context (fn [this] ...) a function returning the context of a reagent component