### PR TITLE
Add CONTRIBUTING.md document

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing to Reagent
+
+:+1::tada: First off, thanks for taking the time to contribute! :tada::+1:
+
+The following is a set of guidelines for contributing to Reagent which is hosted on [Github](fram://github.com/reagent-project/reagent).
+These are just guidelines, not rules. Use your best judgment and feel free to propose changes to this document in a pull request.
+
+## Support questions
+
+**The Github issues for Reagent are for bug reports and feature requests. Support requests and usage questions should go to the [Clojure Slack channel](http://clojurians.net), the [ClojureScript mailing list](https://groups.google.com/forum/#!forum/clojurescript), or the [Reagent mailing list](https://groups.google.com/forum/#!forum/reagent-project).**
+
+## Creating issues for bugs
+
+Check if the issue has already been reported. If possible provide:
+
+* Version of Reagent being used
+* Minimal reproduction steps
+
+## Creating issues for features
+
+Use your best judgement on what is needed here.
+
+## Pull requests
+
+**Create pull requests to the master branch**.
+
+## Pull requests for bugs
+
+If possible provide:
+
+* Code that fixes the bug
+* Failing tests which pass with the new changes
+* Improvements to documentation to make it less likely that others will run into issues (if relevant).
+* Add the change to the Unreleased section of [CHANGELOG.md](CHANGELOG.md)
+
+## Pull requests for features
+
+If possible provide:
+
+* Code that implements the new feature
+* Tests to cover the new feature including all of the code paths
+* Docstrings for functions
+* Documentation examples
+* Add the change to the Unreleased section of [CHANGELOG.md](CHANGELOG.md)


### PR DESCRIPTION
This will help people know what information to put in a bug report or feature request, and prevent people from using the Issues as a support forum.

You may not like people adding things to the changelog, I can take that out. Also, you may prefer all questions go to the reagent mailing list, not to the ClojureScript list?

Relates to #147.