### PR TITLE
Fix bug where some auto-run reactions don't re-run

### DIFF
--- a/src/reagent/ratom.cljs
+++ b/src/reagent/ratom.cljs
@@ -19,7 +19,6 @@
 
 (defn captured [obj]
   (let [c (.-cljsCaptured obj)]
-    (set! (.-cljsCaptured obj) nil)
     c))
 
 (defn- notify-deref-watcher! [derefable]

--- a/test/reagenttest/testratom.cljs
+++ b/test/reagenttest/testratom.cljs
@@ -238,6 +238,26 @@
     (is (= @b 6))
     (is (= runs (running)))))
 
+(deftest reset-in-reaction
+  (let [runs (running)
+        state (rv/atom {})
+        c1 (reaction (get-in @state [:data :a]))
+        c2 (reaction (get-in @state [:data :b]))
+        rxn (rv/make-reaction
+             #(let [cc1 @c1
+                    cc2 @c2]
+                (swap! state assoc :derived (+ cc1 cc2))
+                nil)
+             :auto-run true)]
+    @rxn
+    (is (= (:derived @state) 0))
+    (swap! state assoc :data {:a 1, :b 2})
+    (is (= (:derived @state) 3))
+    (swap! state assoc :data {:a 11, :b 22})
+    (is (= (:derived @state) 33))
+    (dispose rxn)
+    (is (= runs (running)))))
+
 ;; (deftest catching
 ;;   (let [runs (running)
 ;;         a (rv/atom false)


### PR DESCRIPTION
We hit upon a problem where some of our auto-run reactions would not re-run, despite the things they deref'd changing value. To demonstrate: the new test in this PR will fail in current master, but pass with the patch applied. All other tests still pass with the patch applied.

Having >= 2 deref'd reactions that rely on the modified state is key to reproducing. Here's my best go at an english explanation for what's happening:

- `swap!` at test's line 254 happens
- atom notifies its watches (c1 & c2)
- `c1` runs, has changed, & notifies its watches (`rxn`)
- `(capture-derefed <rxn's body>)` runs
  - _(... rxn's body runs ...)_
  - we `swap!` at the very end of rxn's body
  - the atom notifies its watches (c1 and c2)
  - `c1` runs, but hasn't changed, so it doesn't notify `rxn`
  - `c2` runs, has changed, and _does_ notify `rxn`
  - `(capture-derefed <rxn's body>)` runs, and finishes cleanly
    - (`rxn.cljsCaptured` is now the correct list)
  - `(let derefed (captured <rxn>))` runs, returning the correct list
    - (but now `rxn.cljsCaptured` is nil **!** )
  - `(update-watching <rxn> derefed)` runs
    - (`rxn.watching` is now the correct list)
  - _(... unwind ...)_
- `(let derefed (captured <rxn>))` runs, **returning nil** (since `rxn.cljsCaptured` is nil now)
- `(update-watching <rxn> derefed)` is called, but now `derefed` is `nil` (!)
  - (`rxn.watching` is now `nil` because it was clobbered)
- from now on, `rxn` will never re-run

The solution in the patch is to avoid setting `cljsCaptured` to nil inside of `captured`. It will be set to nil again at the beginning of `capture-derefed`, which seems to be what matters. Again, all tests pass with the patch applied.
