### PR TITLE
Update Cljsjs React dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,8 +5,8 @@
 
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/clojurescript "1.7.145"]
-                 [cljsjs/react-dom "15.0.1-0"]
-                 [cljsjs/react-dom-server "15.0.1-0"]]
+                 [cljsjs/react-dom "15.0.1-1"]
+                 [cljsjs/react-dom-server "15.0.1-1"]]
 
   :plugins [[lein-cljsbuild "1.1.0"]
             [codox "0.9.0"]]


### PR DESCRIPTION
The latest Cljsjs React build adds missing nativeEvent property for
SyntheticEvent object on the extern file.

https://github.com/cljsjs/packages/commit/0db9cd856e6d5e35f275811225143233bc43048b