### PR TITLE
Add issue template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,3 @@
+Support questions
+
+The Github issues for Reagent are for bug reports and feature requests. Support requests and usage questions should go to the Clojure Slack channel, the ClojureScript mailing list, or the Reagent mailing list.


### PR DESCRIPTION
This gets shown to every user as they create an issue in GitHub which might be more prominent than the CONTRIBUTING.md banner.