### PR TITLE
Fix react-with-addons example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,16 @@ To use Reagent in an existing project you add this to your dependencies in `proj
 
 This is all you need to do if you want the standard version of React. If you want the version of React with addons, you'd use something like this instead:
 
-    [reagent "0.6.0" :exclusions [cljsjs/react]]
-    [cljsjs/react-with-addons "15.2.1-0"]
+```clj
+:dependencies [[reagent "0.6.0" :exclusions [cljsjs/react-dom cljsjs/react-dom-server]]
+               [cljsjs/react-with-addons "15.2.1-0"]
+               [cljsjs/react-dom "15.2.1-0" :exclusions [cljsjs/react]]
+               [cljsjs/react-dom-server "15.2.1-0" :exclusions [cljsjs/react]]]
+;; or, using global exclusions
+:exclusions [cljsjs/react]
+:dependencies [[reagent "0.6.0"]
+               [cljsjs/react-with-addons "15.2.1-0"]]
+```
 
 If you want to use your own build of React (or React from a CDN), you have to use `:exclusions` variant of the dependency, and also provide a file named "cljsjs/react.cljs", containing just `(ns cljsjs.react)`, in your project.
 


### PR DESCRIPTION
Reagent now depends on `cljsjs/react-dom` and `cljsjs/react-dom-server` so
direct dependency to `cljsjs/react` won't work.

Btw. if wanted, the old way could be enabled by adding direct dependency to `cljsjs/react` to Reagent, and adding `cljsjs/react` exclusions to dom and dom-server deps on Reagent side. My opinion is to not do tricks here and leave this to the user. Using global exclusions is probably the best way to do this, because other libs beside Reagent might anyway have transitive dependency to `cljsjs/react` and global exclusions  takes care of those also.