### PR TITLE
Support synthetic text input components

### DIFF
--- a/src/reagent/core.cljs
+++ b/src/reagent/core.cljs
@@ -50,9 +50,11 @@
 (defn adapt-react-class
   "Returns an adapter for a native React class, that may be used
   just like a Reagent component function or class in Hiccup forms."
-  [c]
-  (assert-some c "Component")
-  (tmpl/adapt-react-class c))
+  ([c opts]
+   (assert-some c "Component")
+   (tmpl/adapt-react-class c opts))
+  ([c]
+   (adapt-react-class c {})))
 
 (defn reactify-component
   "Returns an adapter for a Reagent component, that may be used from

--- a/src/reagent/impl/template.cljs
+++ b/src/reagent/impl/template.cljs
@@ -343,9 +343,7 @@
 
 (defn native-element [parsed argv first]
   (let [comp ($ parsed :name)
-        synthetic-input ($ parsed :syntheticInput)
-        synthetic-on-update ($ parsed :syntheticOnUpdate)
-        synthetic-on-change ($ parsed :syntheticOnChange)]
+        synthetic-input ($ parsed :syntheticInput)]
     (let [props (nth argv first nil)
           hasprops (or (nil? props) (map? props))
           jsprops (convert-props (if hasprops props) parsed)
@@ -353,7 +351,13 @@
       (if (or synthetic-input (input-component? comp))
         (-> (if synthetic-input
               ;; If we are dealing with a synthetic input, use the synthetic-input-spec form:
-              [(reagent-synthetic-input) synthetic-on-update synthetic-on-change argv comp jsprops first-child]
+              [(reagent-synthetic-input)
+               ($ parsed :syntheticOnUpdate)
+               ($ parsed :syntheticOnChange)
+               argv
+               comp
+               jsprops
+               first-child]
               ;; Else use the regular input-spec form:
               [(reagent-input) argv comp jsprops first-child])
             (with-meta (meta argv))


### PR DESCRIPTION
Submitting PR for review and discussion at this stage.

**Problem:** Reagent controls text input components to handle updates and caret repositioning correctly, but this assumes that only `<input>` elements are rendered by text input components in Hiccup. This excludes Reagent users that, for example, wrap their `<input>` element in a `<div>` or otherwise have arbitrary behaviour/structure. The result is that these components have caret positioning bugs, as seen in #265.

**Proposed solution:** Add more affordances to Reagent's input handling API so that "synthetic" input components (i.e. not just rendering `<input>` at the root) can inform Reagent of how to locate the correct input element to manage within its DOM tree; and what to do when values change.

In particular, in `template.cljs`:

* Take a map of options with `r/adapt-react-class` with optional overrides for input handling where applicable.
* Allow `input-component?` to detect synthetic inputs as input components needing caret control on user interactive updates.
* Allow `input-set-value` to be intercepted by synthetic inputs so they can refine which `node` is the correct input element inside their DOM subtree.
* Add a hook for `on-write` so synthetic inputs can respond appropriately to manage their special local state when new values are meant to be written to the component.
* Allow intercepting `on-change` so synthetic inputs can transform values or sync state.

These were all motivated by #265 so that cljs-react-material-ui could get its TextField component working with Reagent's input handling, but the changes are meant to be agnostic of client quirks. You can see an example of usage in this snippet: https://github.com/madvas/cljs-react-material-ui/issues/17#issuecomment-268807607

How does this approach look?