### PR TITLE
Make reagent self-host compatible

### DIFF
--- a/demo/reagentdemo/syntax.clj
+++ b/demo/reagentdemo/syntax.clj
@@ -1,6 +1,5 @@
 (ns reagentdemo.syntax
-  (:require [clojure.java.io :as io]
-            [clojure.string :as string]))
+  (:require [clojure.string :as string]))
 
 
 ;;; Source splitting

--- a/src/reagent/interop.clj
+++ b/src/reagent/interop.clj
@@ -55,7 +55,7 @@
     (assert field (str "Field name must start with - in " field))
     `(aset ~object ~@names ~value)))
 
-(defmacro .' [& args]
+#_(defmacro .' [& args]
   ;; Deprecated since names starting with . cause problems with bootstrapped cljs.
   (let [ns (str cljs.analyzer/*cljs-ns*)
         line (:line (meta &form))]
@@ -64,7 +64,7 @@
                ". Use reagent.interop/$ instead.")))
   `($ ~@args))
 
-(defmacro .! [& args]
+#_(defmacro .! [& args]
   ;; Deprecated since names starting with . cause problems with bootstrapped cljs.
   (let [ns (str cljs.analyzer/*cljs-ns*)
         line (:line (meta &form))]

--- a/src/reagent/interop.clj
+++ b/src/reagent/interop.clj
@@ -1,6 +1,5 @@
 (ns reagent.interop
-  (:require [clojure.string :as string :refer [join]]
-            [clojure.java.io :as io]))
+  (:require [clojure.string :as string :refer [join]]))
 
 (defn- js-call [f args]
   (let [argstr (->> (repeat (count args) "~{}")

--- a/src/reagent/interop.clj
+++ b/src/reagent/interop.clj
@@ -54,21 +54,3 @@
   (let [[field names] (dot-args object field)]
     (assert field (str "Field name must start with - in " field))
     `(aset ~object ~@names ~value)))
-
-#_(defmacro .' [& args]
-  ;; Deprecated since names starting with . cause problems with bootstrapped cljs.
-  (let [ns (str cljs.analyzer/*cljs-ns*)
-        line (:line (meta &form))]
-    (binding [*out* *err*]
-      (println "WARNING: reagent.interop/.' is deprecated in " ns " line " line
-               ". Use reagent.interop/$ instead.")))
-  `($ ~@args))
-
-#_(defmacro .! [& args]
-  ;; Deprecated since names starting with . cause problems with bootstrapped cljs.
-  (let [ns (str cljs.analyzer/*cljs-ns*)
-        line (:line (meta &form))]
-    (binding [*out* *err*]
-      (println "WARNING: reagent.interop/.! is deprecated in " ns " line " line
-               ". Use reagent.interop/$! instead.")))
-  `($! ~@args))


### PR DESCRIPTION
This PR contains 2 changes that makes reagent self-host compatible:

1. remove JVM related code in macro files
2. remove [deprecated macro code](https://github.com/reagent-project/reagent/blob/master/src/reagent/interop.clj#L59-L75) as it causes trouble in self-host cljs. See the problematice code in [klipse](http://app.klipse.tech/?cljs_in=%0A(defmacro%20.%27%20%5B%26%20args%5D%0A%20%20%3B%3B%20Deprecated%20since%20names%20starting%20with%20.%20cause%20problems%20with%20bootstrapped%20cljs.%0A%20%20(let%20%5Bns%20(str%20cljs.analyzer%2F*cljs-ns*)%0A%20%20%20%20%20%20%20%20line%20(%3Aline%20(meta%20%26form))%5D%0A%20%20%20%20(binding%20%5B*out*%20*err*%5D%0A%20%20%20%20%20%20(println%20%22WARNING%3A%20reagent.interop%2F.%27%20is%20deprecated%20in%20%22%20ns%20%22%20line%20%22%20line%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22.%20Use%20reagent.interop%2F%24%20instead.%22)))%0A%20%20%60(%24%20~%40args)))

