### PR TITLE
Upgrade to React 15.5 and use React ES6 class component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "dependencies": {
-        "react": "^15.2.1",
-        "react-dom": "^15.2.1"
+        "react": "^15.5.0",
+        "react-dom": "^15.5.0"
     },
     "scripts": {
         "bundle": "webpack && NODE_ENV=production webpack -p"

--- a/project.clj
+++ b/project.clj
@@ -5,8 +5,8 @@
 
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/clojurescript "1.8.51"]
-                 [cljsjs/react-dom "15.4.2-2"]
-                 [cljsjs/react-dom-server "15.4.2-2"]]
+                 [cljsjs/react-dom "15.5.0-0"]
+                 [cljsjs/react-dom-server "15.5.0-0"]]
 
   :plugins [[lein-cljsbuild "1.1.5"]
             [lein-codox "0.10.3"]]


### PR DESCRIPTION
This PR moves away from using `React.createClass` to using a React ES6 Component. See #292 

Their should be no change in the API of Reagent. This is purely an implementation change. So we need to make sure that no existing code breaks.