### PR TITLE
Fix partial-ifn with latest Cljs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :description "A simple ClojureScript interface to React"
 
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/clojurescript "1.8.51"]
+                 [org.clojure/clojurescript "1.9.655"]
                  [cljsjs/react-dom "15.5.4-0"]
                  [cljsjs/react-dom-server "15.5.4-0"]
                  [cljsjs/create-react-class "15.5.3-0"]]

--- a/src/reagent/core.cljs
+++ b/src/reagent/core.cljs
@@ -334,10 +334,9 @@
   (batch/do-after-render f))
 
 (defn partial
-  "Works just like clojure.core/partial, except that it is an IFn, and
-  the result can be compared with ="
+  "Works just like clojure.core/partial, but the result can be compared with ="
   [f & args]
-  (util/partial-ifn. f args nil))
+  (util/make-partial-fn f args))
 
 (defn component-path
   ;; Try to return the path of component c as a string.

--- a/src/reagent/impl/util.cljs
+++ b/src/reagent/impl/util.cljs
@@ -65,16 +65,61 @@
         str
         (clojure.string/replace "$" "."))))
 
-(deftype partial-ifn [f args ^:mutable p]
+(deftype PartialFn [pfn f args]
+  Fn
   IFn
-  (-invoke [_ & a]
-    (or p (set! p (apply clojure.core/partial f args)))
-    (apply p a))
+  (-invoke [_]
+    (pfn))
+  (-invoke [_ a]
+    (pfn a))
+  (-invoke [_ a b]
+    (pfn a b))
+  (-invoke [_ a b c]
+    (pfn a b c))
+  (-invoke [_ a b c d]
+    (pfn a b c d))
+  (-invoke [_ a b c d e]
+    (pfn a b c d e))
+  (-invoke [_ a b c d e f]
+    (pfn a b c d e f))
+  (-invoke [_ a b c d e f g]
+    (pfn a b c d e f g))
+  (-invoke [_ a b c d e f g h]
+    (pfn a b c d e f g h))
+  (-invoke [_ a b c d e f g h i]
+    (pfn a b c d e f g h i))
+  (-invoke [_ a b c d e f g h i j]
+    (pfn a b c d e f g h i j))
+  (-invoke [_ a b c d e f g h i j k]
+    (pfn a b c d e f g h i j k))
+  (-invoke [_ a b c d e f g h i j k l]
+    (pfn a b c d e f g h i j k l))
+  (-invoke [_ a b c d e f g h i j k l m]
+    (pfn a b c d e f g h i j k l m))
+  (-invoke [_ a b c d e f g h i j k l m n]
+    (pfn a b c d e f g h i j k l m n))
+  (-invoke [_ a b c d e f g h i j k l m n o]
+    (pfn a b c d e f g h i j k l m n o))
+  (-invoke [_ a b c d e f g h i j k l m n o p]
+    (pfn a b c d e f g h i j k l m n o p))
+  (-invoke [_ a b c d e f g h i j k l m n o p q]
+    (pfn a b c d e f g h i j k l m n o p q))
+  (-invoke [_ a b c d e f g h i j k l m n o p q r]
+    (pfn a b c d e f g h i j k l m n o p q r))
+  (-invoke [_ a b c d e f g h i j k l m n o p q r s]
+    (pfn a b c d e f g h i j k l m n o p q r s))
+  (-invoke [_ a b c d e f g h i j k l m n o p q r s t]
+    (pfn a b c d e f g h i j k l m n o p q r s t))
+  (-invoke [_ a b c d e f g h i j k l m n o p q r s t rest]
+    (apply pfn a b c d e f g h i j k l m n o p q r s t rest))
   IEquiv
   (-equiv [_ other]
     (and (= f (.-f other)) (= args (.-args other))))
   IHash
   (-hash [_] (hash [f args])))
+
+(defn make-partial-fn [f args]
+  (->PartialFn (apply partial f args) f args))
 
 (defn- merge-class [p1 p2]
   (let [class (when-let [c1 (:class p1)]

--- a/src/reagent/ratom.cljs
+++ b/src/reagent/ratom.cljs
@@ -564,7 +564,7 @@
 
 (defn make-wrapper [value callback-fn args]
   (->Wrapper value
-             (util/->partial-ifn callback-fn args nil)
+             (util/make-partial-fn callback-fn args)
              false nil))
 
 

--- a/test/reagenttest/testreagent.cljs
+++ b/test/reagenttest/testreagent.cljs
@@ -349,7 +349,8 @@
     (is (= p1 (r/partial vector 1 2)))
     (is (ifn? p1))
     (is (= (r/partial vector 1 2) p1))
-    (is (not= p1 (r/partial vector 1 3)))))
+    (is (not= p1 (r/partial vector 1 3)))
+    (is (= (hash p1) (hash (r/partial vector 1 2))))))
 
 (deftest test-null-component
   (let [null-comp (fn [do-show]


### PR DESCRIPTION
Old implementation incorrectly used variadic arity for -invoke
implementation. Variadic artities for protocols are not supported by
Cljs. The old code as worked by luck but was broken by a recent change:
https://dev.clojure.org/jira/browse/CLJS-2099

New implementation properly implements all the artities for -invoke. New
implementation creates the partial fn in a constructor function, so -invoke
code doesn't need to do that. New implementation also implements Fn.