### PR TITLE
Don't rename props for custom elements

### DIFF
--- a/test/reagenttest/testreagent.cljs
+++ b/test/reagenttest/testreagent.cljs
@@ -1064,3 +1064,12 @@
   (is (re-find #"<div style=\"text-align:center(;?)\">foo</div>"
                (server/render-to-static-markup
                  [:div {:style {:text-align "center"}} "foo"]))))
+
+(deftest custom-element-class-prop
+  (is (re-find #"<custom-element class=\"foobar\">foo</custom-element>"
+               (server/render-to-static-markup
+                 [:custom-element {:class "foobar"} "foo"])))
+
+  (is (re-find #"<custom-element class=\"foobar\">foo</custom-element>"
+               (server/render-to-static-markup
+                 [:custom-element.foobar "foo"]))) )


### PR DESCRIPTION
Custom element names must always contain hyphen so we can use that to
keep track of which elements are native vs. custom when parsing tag
name.

Fixes #322

I don't like much copying twenty lines of code (prop renaming), but seemed like the easiest, and probably most efficient way to do this. Parse-tag result is cached, so per different hiccup-tag, we need to check if name contains hyphens only once. Then convert-props can use this `custom` property from parsed object to select which function to use to convert props to JS.

I moved the handling for ID and class from hiccup-tag so it modifies the Clojure props map, instead of JS object. This could have some effect on performance.