### PR TITLE
Catch not= throwing exceptions and log a warning

### DIFF
--- a/src/reagent/impl/component.cljs
+++ b/src/reagent/impl/component.cljs
@@ -167,7 +167,10 @@
                          new-argv ($ nextprops :argv)
                          noargv (or (nil? old-argv) (nil? new-argv))]
                      (cond
-                       (nil? f) (or noargv (not= old-argv new-argv))
+                       (nil? f) (or noargv (try (not= old-argv new-argv)
+                                                (catch :default e
+                                                  (warn "Exception thrown while comparing argv's in shouldComponentUpdate. You probably need to set different keys." old-argv new-argv e)
+                                                  false)))
                        noargv (.call f c c (get-argv c) (props-argv c nextprops))
                        :else  (.call f c c old-argv new-argv))))))
 


### PR DESCRIPTION
Under [certain conditions](https://dev.clojure.org/jira/browse/CLJ-2325), `not=` in the default `shouldComponentUpdate` function can throw an exception.

You can boil this down to:

```cljs
cljs.user=> (not= {:todos 1} (sorted-map 1 2))
Cannot compare :todos to 1
	cljs.core/-compare [cljs.core/IComparable] (cljs/core.cljs:9995:14)
	-compare (cljs/core.cljs:807:24)
	compare (cljs/core.cljs:2360:5)
	entry-at (cljs/core.cljs:8401:25)
	cljs.core/-lookup [cljs.core/ILookup] (cljs/core.cljs:8468:24)
	cljs.core/-equiv [cljs.core/IEquiv] (cljs/core.cljs:6560:32)
	-equiv (cljs/core.cljs:695:23)
	= (cljs/core.cljs:1247:16)
```

This is ultimately a bug in ClojureScript (and Clojure), but in the general case, `not=` doesn't guarantee that it won't throw, and there are weird edge cases like this that pop up now and then when comparing composite data types (especially when they are not standard vector/map/set/list's).

You could imagine try/catching and swallowing the exception, which is technically correct as you can make a good assumption that if a comparison failed then the two objects aren't equal. But this feels pretty gross.

I propose that there is a try/catch which prints a warning/error explaining what happened, and that you can fix it by synthetically setting the key to be different for each piece of data you provide as an argument to the component.

Todo:

- [ ] Finish wording in error message
- [ ] Add a docs page explaining in more detail how to address this issue
- [ ] Test the performance impact of try/catch in this position
- [ ] Add tests covering this error