### PR TITLE
Keep reference to real synthetic input component

### DIFF
--- a/src/reagent/impl/template.cljs
+++ b/src/reagent/impl/template.cljs
@@ -213,7 +213,7 @@
           synthetic-on-update ($ this :cljsSyntheticOnUpdate)]
       (when (not= rendered-value dom-value)
         (if (fn? synthetic-on-update)
-          (synthetic-on-update input-node-set-value node rendered-value dom-value this)
+          (synthetic-on-update input-node-set-value node ($ this :cljsRealInputComponent) rendered-value dom-value this)
           (input-node-set-value node rendered-value dom-value this {}))))))
 
 (defn input-handle-change [this on-change e]
@@ -243,6 +243,24 @@
            on-change (if synthetic-on-change
                        (partial synthetic-on-change on-change)
                        on-change)]
+
+       ;; Setup ref for synthetic inputs, to get reference to the real
+       ;; component instance, for on-update function.
+       ;; The ref function is initialized once (and saved to component object)
+       ;; and then recreated if user provides new original ref function.
+       ;; The created ref function calls the original ref function.
+       (when synthetic-on-update
+         (let [original-ref ($ jsprops :ref)]
+           (when (or (not ($ this :cljsInputRef))
+                     (not (= original-ref ($ this :cljsOriginalRef))))
+             ($! this :cljsInputRef (fn [c]
+                                      ($! this :cljsRealInputComponent c)
+                                      (if original-ref
+                                        (original-ref c)))))
+
+           ($! this :cljsOriginalRef original-ref)
+           ($! jsprops :ref ($ this :cljsInputRef))))
+
        (when-not ($ this :cljsInputLive)
          ;; set initial value
          ($! this :cljsInputLive true)


### PR DESCRIPTION
To implement proper on-update function for React input wrapper components, reference to the real component is probably needed.

Discussion at https://github.com/madvas/cljs-react-material-ui/issues/17
Example at https://github.com/Deraen/problems/blob/reagent-material-ui-text-field/src/hello_world/core.cljs#L16