### PR TITLE
Add link to FAQ and tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Reagent provides a way to write efficient React components using (almost) nothin
   * **[Detailed intro with live examples](http://reagent-project.github.io/)**
   * **[News](http://reagent-project.github.io/news/index.html)**
   * **[API Documentation](http://reagent-project.github.io/docs/master/)**
+  * **[Tutorials and FAQ](https://github.com/reagent-project/reagent/tree/master/docs)
   * **Community discussion and support channels**
     * **[#reagent](https://clojurians.slack.com/messages/reagent/)** channel in [Clojure Slack](http://clojurians.net/)
     * **[Reagent Project Mailing List](https://groups.google.com/forum/#!forum/reagent-project)**


### PR DESCRIPTION
Not sure if this belong in the readme yet because they're some draft being linked to, but I found these documentations more useful than the API Documentation. I think it's worth pointing to.