### PR TITLE
Comparing PartialFn to nil is false/unexceptional #385

### DIFF
--- a/src/reagent/impl/util.cljs
+++ b/src/reagent/impl/util.cljs
@@ -114,7 +114,9 @@
     (apply pfn a b c d e f g h i j k l m n o p q r s t rest))
   IEquiv
   (-equiv [_ other]
-    (and (= f (.-f other)) (= args (.-args other))))
+    (and (instance? PartialFn other)
+         (= f (.-f other))
+         (= args (.-args other))))
   IHash
   (-hash [_] (hash [f args])))
 


### PR DESCRIPTION
Fixes #385 

I forked from 0.7.0 ~~since I selfishly would like to see this in a 0.7.1 (if its not a pain).
But if not~~ it should cleanly merge on HEAD/0.8x.

Thanks!