### PR TITLE
small rearrangement

### DIFF
--- a/doc/WhenDoComponentsUpdate.md
+++ b/doc/WhenDoComponentsUpdate.md
@@ -123,8 +123,9 @@ And, finally, a Form-2 parent Component which uses these two child components:
     (fn  parent-renderer 
       []
       [:div 
-        [more-button counter]            ;; no @ on counter
-        [greet-number @counter]])))      ;; notice the @. The prop is an int
+        [greet-number @counter]      ;; notice the @. The prop is an int
+        [more-button counter]])))    ;; no @ on counter
+	
 ```
 
 With this setup, answer this question: what rerendering happens each time the `more-button` gets clicked and `counter` gets incremented? 


### PR DESCRIPTION
Keep the order of usage the same as the order declared, so child #1 is used first & child #2 is used second.