### PR TITLE
Fix material-ui example for version 4.1.0-0

### DIFF
--- a/examples/material-ui/project.clj
+++ b/examples/material-ui/project.clj
@@ -3,7 +3,9 @@
                  [org.clojure/clojurescript "1.10.516"]
                  [reagent "0.8.1"]
                  [figwheel "0.5.18"]
-                 [cljsjs/material-ui "3.9.1-0"]
+                 [cljsjs/react "16.8.3-0"]
+                 [cljsjs/react-dom "16.8.3-0"]
+                 [cljsjs/material-ui "4.1.0-0"]
                  [cljsjs/material-ui-icons "3.0.1-0"]]
 
   :plugins [[lein-cljsbuild "1.1.7"]
@@ -40,8 +42,8 @@
                 :output-to "target/cljsbuild/client-npm/public/js/main.js"
                 :asset-path "js/out"
                 :install-deps true
-                :npm-deps {react "16.8.1"
-                           react-dom "16.8.1"
-                           "@material-ui/core" "3.1.1"
+                :npm-deps {react "16.8.3"
+                           react-dom "16.8.3"
+                           "@material-ui/core" "4.1.0"
                            "@material-ui/icons" "3.0.1"}
                 :process-shim true}}}})


### PR DESCRIPTION
Material-ui 4.1.0-0 requires react/react-dom 16.8.3