### PR TITLE
Support shadow-cljs

### DIFF
--- a/src/deps.cljs
+++ b/src/deps.cljs
@@ -1,0 +1,2 @@
+{:npm-deps {"react" "16.8.6"
+            "react-dom" "16.8.6"}}


### PR DESCRIPTION
This adds transitive dependency resolution for [shadow-cljs](http://shadow-cljs.org/).

shadow-cljs does not support CLJSJS `:foreign-libs`, instead favouring direct NPM dependencies. The official way for libraries to support providing transitive NPM dependencies to shadow-cljs is a `:npm-deps` key in a `deps.cljs` file as per this PR.

shadow-cljs will read all found `deps.cljs` with `:npm-deps` on startup, do best effort conflict resolution and run `npm install the package@version` if the package is not in `package.json` already (Thanks to @thheller on #shadow-cljs on clojurians Slack for that explanation). 

Without this change, depending on reagent results in the following issue:
```
[:app] Build failure:
The required namespace "react" is not available, it was required by "reagent/core.cljs".
The namespace was provided via :foreign-libs which is not supported.
Please refer to https://shadow-cljs.github.io/docs/UsersGuide.html#cljsjs for more information.
You may just need to run:
  npm install react
```

With this change, transitive NPM dependencies are automatically resolved:
``` 
running: npm install --save react@16.8.6 react-dom@16.8.6
/home/isaac/src/re-frame/npm-deps-test
├─┬ react@16.8.6 
│ ├─┬ loose-envify@1.4.0 
│ │ └── js-tokens@4.0.0 
│ ├── object-assign@4.1.1 
│ ├─┬ prop-types@15.7.2 
│ │ └── react-is@16.9.0 
│ └── scheduler@0.13.6 
└── react-dom@16.8.6 
```