### PR TITLE
Remove deprecated dependency cljsjs/react-dom-server

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,8 +8,7 @@
                  ;; Without direct react dependency, other packages,
                  ;; like react-leaflet might have closer dependency to a other version.
                  [cljsjs/react "16.8.6-0"]
-                 [cljsjs/react-dom "16.8.6-0"]
-                 [cljsjs/react-dom-server "16.8.6-0"]]
+                 [cljsjs/react-dom "16.8.6-0"]]
 
   :plugins [[lein-cljsbuild "1.1.7"]
             [lein-doo "0.1.11"]


### PR DESCRIPTION
It is [deprecated](https://github.com/cljsjs/packages/blob/master/react/build.boot#L68) and included in the react-dom package.