### PR TITLE
Added Dependency to help with compilers

### DIFF
--- a/examples/material-ui/src/example/core.cljs
+++ b/examples/material-ui/src/example/core.cljs
@@ -1,5 +1,6 @@
 (ns example.core
-  (:require [reagent.core :as r]
+  (:require [cljsjs.material-ui] ; Needed to use any sort of advanced compiling
+            [reagent.core :as r]
             ;; Scoped names require Cljs 1.10.439
             ["@material-ui/core" :as mui]
             ["@material-ui/core/styles" :refer [createMuiTheme withStyles]]


### PR DESCRIPTION
This is one of the few working examples of Material-UI with reagent.  When building for prod, it is needed to include `[cljsjs.material-ui]`, so I added that to leave a bread crumb for new comers.