### PR TITLE
Fix error in CreatingReagentComponents.md

### DIFF
--- a/doc/CreatingReagentComponents.md
+++ b/doc/CreatingReagentComponents.md
@@ -101,6 +101,7 @@ Referring to the example in [React's documentation](https://reactjs.org/docs/fra
 
 ```cljs
 (defn columns
+  []
   [:<>
     [:td "Hello"]
     [:td "World"]]


### PR DESCRIPTION
Without the empty params vector, the columns example caused compilation errors when including it in a script.