### PR TITLE
Use component constructor to keep track of mount order

### DIFF
--- a/src/reagent/impl/batching.cljs
+++ b/src/reagent/impl/batching.cljs
@@ -29,8 +29,8 @@
   ;; top-most component is mounted last and gets largest
   ;; number. This is reverse compared to WillMount where method
   ;; for top component gets called first.
-  (- (.-cljsMountOrder c2)
-     (.-cljsMountOrder c1)))
+  (- (.-cljsMountOrder c1)
+     (.-cljsMountOrder c2)))
 
 (defn run-queue [a]
   ;; sort components by mount order, to make sure parents

--- a/src/reagent/impl/component.cljs
+++ b/src/reagent/impl/component.cljs
@@ -229,12 +229,7 @@
 
     :componentDidMount
     (fn componentDidMount []
-      (this-as c
-        ;; This method is called after everything inside the
-        ;; has been mounted. This is reverse compared to WillMount.
-        (set! (.-cljsMountOrder ^clj c) (batch/next-mount-count))
-        (when-not (nil? f)
-          (.call f c c))))
+      (this-as c (.call f c c)))
 
     :componentWillUnmount
     (fn componentWillUnmount []
@@ -259,7 +254,6 @@
 ;; Though the value is nil here, the wrapper function will be
 ;; added to class to manage Reagent ratom lifecycle.
 (def obligatory {:shouldComponentUpdate nil
-                 :componentDidMount nil
                  :componentWillUnmount nil})
 
 (def dash-to-method-name (util/memoize-1 util/dash-to-method-name))
@@ -340,6 +334,7 @@
                   (construct this props))
                 (when get-initial-state
                   (set! (.-state this) (get-initial-state this)))
+                (set! (.-cljsMountOrder ^clj this) (batch/next-mount-count))
                 this))]
 
     (gobj/extend (.-prototype cmp) (.-prototype react/Component) methods)

--- a/test/reagenttest/testreagent.cljs
+++ b/test/reagenttest/testreagent.cljs
@@ -1371,3 +1371,28 @@
           (r/flush)
           (is (= {:height 20} @did-update))
           (.removeChild js/document.body div))))))
+
+(deftest issue-462-test
+  (when isClient
+    (let [val (r/atom 0)
+          render (atom 0)
+          a (fn issue-462-a [nr]
+              (js/console.log "rendering a")
+              (swap! render inc)
+              [:h1 "Value " nr])
+          b (fn issue-462-b []
+              [:div
+               ^{:key @val}
+               [a @val]])
+          c (fn issue-462-c []
+              ^{:key @val}
+              [b])]
+      (with-mounted-component [c]
+        (fn [c div]
+          (is (= 1 @render))
+          (reset! val 1)
+          (r/flush)
+          (is (= 2 @render))
+          (reset! val 0)
+          (r/flush)
+          (is (= 3 @render)))))))


### PR DESCRIPTION
Parent components need to have smaller mount-order numbers than their
children, or else this will break when only the children are rerendered
and get new number.

Fixes #462