### PR TITLE
Include path in assert error for cursors

### DIFF
--- a/src/reagent/ratom.cljs
+++ b/src/reagent/ratom.cljs
@@ -321,7 +321,9 @@
               (and (ifn? src)
                    (not (vector? src))))
           (str "src must be a reactive atom or a function, not "
-               (pr-str src)))
+               (pr-str src)
+               " while attempting to get path: "
+               (pr-str path))
   (->RCursor src path nil nil nil))
 
 


### PR DESCRIPTION
Hopefully a fairly uncontroversial PR! 

Including path can help track down which particular cursor is misbehaving, ie in a React Native project, I have the following error message:

![image](https://user-images.githubusercontent.com/201036/71717282-e89dc280-2e17-11ea-819a-c4c48d983af8.png)

This isn't particularly helpful, but when the path is included it becomes a lot easier to find which particular cursor is responsible for the assert failure.
