### PR TITLE
Fix merge-props without classes

### DIFF
--- a/src/reagent/impl/util.cljs
+++ b/src/reagent/impl/util.cljs
@@ -147,7 +147,9 @@
            rst)))
 
 (defn- merge-class [p1 p2]
-  (assoc p2 :class (class-names (:class p1) (:class p2))))
+  (if-let [names (class-names (:class p1) (:class p2))]
+    (assoc p2 :class names)
+    p2))
 
 (defn- merge-style [p1 p2]
   (let [style (when-let [s1 (:style p1)]

--- a/src/reagent/impl/util.cljs
+++ b/src/reagent/impl/util.cljs
@@ -147,8 +147,8 @@
            rst)))
 
 (defn- merge-class [p1 p2]
-  (if-let [names (class-names (:class p1) (:class p2))]
-    (assoc p2 :class names)
+  (if (or (contains? p1 :class) (contains? p2 :class))
+    (assoc p2 :class (class-names (:class p1) (:class p2)))
     p2))
 
 (defn- merge-style [p1 p2]

--- a/test/reagent/impl/util_test.cljs
+++ b/test/reagent/impl/util_test.cljs
@@ -56,6 +56,11 @@
            (util/merge-props {:disabled true :style {:flex 1} :class "foo"}
                              {:disabled false :style {:flex-direction "row"} :class "bar"}))))
 
+  (testing "two arguments without classes"
+    (is (= {:disabled false :style {:flex 1 :flex-direction "row"}}
+           (util/merge-props {:disabled true :style {:flex 1}}
+                             {:disabled false :style {:flex-direction "row"}}))))
+
   (testing "n arguments"
     (is (= {:disabled false
             :checked true


### PR DESCRIPTION
This PR fixes a minor issue with `merge-props`. When called with 2 or more arguments without a `:class` key `merge-props` returns a result with `:class nil`. `semantic-ui-react` interprets the presence of `:class` key with value `nil`  as "remove all classes from the component".

This fix does not add `:class` key at all if no classes are present in the arguments to `merge-props`.

[Test run log](https://gist.github.com/achikin/e01c6106ec824d9d2faa9024d67cd154)