### PR TITLE
Update reference to reagent.dom from reagent.core

### DIFF
--- a/doc/UsingHiccupToDescribeHTML.md
+++ b/doc/UsingHiccupToDescribeHTML.md
@@ -112,7 +112,7 @@ can be written as:
 
 ## Rendering Hiccup
 
-The primary entrypoint to the reagent library is `reagent.core/render`.
+The primary entrypoint to the reagent library is `reagent.dom/render`.
 
 ```clojure
 (ns example


### PR DESCRIPTION
Looks like it's just out of date now render is being moved into a separate namespace? Hope this helps! Thanks 😄 