### PR TITLE
Polish key-from-vec

### DIFF
--- a/src/reagent/impl/template.cljs
+++ b/src/reagent/impl/template.cljs
@@ -284,14 +284,10 @@
   (when (map? x)
     (try-get-key x)))
 
-(defn key-from-vec [v]
-  (if-some [k (-> (meta v) get-key)]
-    k
-    (or (-> v (nth 1 nil) get-key)
-        ;; :> is a special case because properties map is the first
-        ;; element of the vector.
-        (if (= :> (nth v 0 nil))
-          (get-key (nth v 2 nil))))))
+(def key-from-vec
+  (some-fn #(get-key (meta %))
+           #(get-key (get % 1))
+           #(when (= (get % 0) :>) (get-key (get % 2)))))
 
 (defn reag-element [tag v]
   (let [c (comp/as-class tag)


### PR DESCRIPTION
Don't know if it's acceptable change, but I think now `key-from-vec` fn looks a bit better. Also I replaced `(nth v idx nil)` with `(get v idx)`. The latter doesn't throw IndexOutOfBounds exception, and at least not slower than the former.

```
(js/console.log "nth" (time (dotimes [x 50000000] (nth [1 2 3] 3 nil))))
;; => "Elapsed time: 3583.530000 msecs"

(js/console.log "get" (time (dotimes [x 50000000] (get [2 3 4] 3))))
;; => "Elapsed time: 2635.350000 msecs"
```