### PR TITLE
Update ManagingState.md

### DIFF
--- a/doc/ManagingState.md
+++ b/doc/ManagingState.md
@@ -76,8 +76,8 @@ Here’s an example that uses event handling with `rswap!`:
 (defn name-edit [id]
   (let [p @(r/track person id)]
 	[:div
-	 [:input {:value (:name p)
-			  :on-change #(emit [:set-name id (.-target.value %)])}]]))
+	 [:input {:value     (:name p)
+		  :on-change #(emit [:set-name id (.-target.value %)])}]]))
 
 (defn edit-fields []
   (let [ids @(r/track person-keys)]
@@ -85,9 +85,9 @@ Here’s an example that uses event handling with `rswap!`:
 	 [name-list]
 	 (for [i ids]
 	   ^{:key i} [name-edit i])
-	 [:input {:type 'button
-			  :value "Add person"
-			  :on-click #(emit [:add-person])}]]))
+	 [:input {:type     'button
+	          :value    "Add person"
+	          :on-click #(emit [:add-person])}]]))
 ```
 
 All events are passed through the emit function, consisting of a trivial application of `rswap!` and some optional logging. This is the only place where application state actually changes – the rest is pure functions.


### PR DESCRIPTION
Fixes alignment of map entries.

Please let me know, if you'd like help here, whether you'd prefer atomic commits or not for doc fixes?
The alternative would be a single commit containing unrelated doc fixes, so a name like 'various formatting fixes'.