### PR TITLE
Add reagent.core/render placeholder, throwing informative runtime error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- DOM related functions have been removed from `reagent.core` namespace.
+    - There is deprecated no-op `render` function on core ns, this will show
+    deprecation warning during compilation and throw runtime error about
+    function being moved. This should be easier to debug than just
+    warning about missing var and calling null fn on runtime.
+
 ## 1.0.0-alpha2 (2020-05-13)
 
 **[compare](https://github.com/reagent-project/reagent/compare/v1.0.0-alpha1...v1.0.0-alpha2)**
@@ -41,10 +49,6 @@ class components**
     - [Check example](./examples/functional-components-and-hooks/src/example/core.cljs)
 - DOM related functions have been removed from `reagent.core` namespace.
     - These were deprecated in the previous release.
-    - There is deprecated no-op `render` function on core ns, this will show
-    deprecation warning during compilation and throw runtime error about
-    function being moved. This should be easier to debug than just
-    warning about missing var and calling null fn on runtime.
 - Change RAtom (all types) print format to be readable using ClojureScript reader,
 similar to normal Atom ([#439](https://github.com/reagent-project/reagent/issues/439))
     - Old print output: `#<Atom: 0>`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ class components**
     - [Check example](./examples/functional-components-and-hooks/src/example/core.cljs)
 - DOM related functions have been removed from `reagent.core` namespace.
     - These were deprecated in the previous release.
+    - There is deprecated no-op `render` function on core ns, this will show
+    deprecation warning during compilation and throw runtime error about
+    function being moved. This should be easier to debug than just
+    warning about missing var and calling null fn on runtime.
 - Change RAtom (all types) print format to be readable using ClojureScript reader,
 similar to normal Atom ([#439](https://github.com/reagent-project/reagent/issues/439))
     - Old print output: `#<Atom: 0>`

--- a/src/reagent/core.clj
+++ b/src/reagent/core.clj
@@ -1,6 +1,5 @@
 (ns reagent.core
-  (:require [reagent.ratom :as ra]
-            cljs.analyzer.api))
+  (:require [reagent.ratom :as ra]))
 
 (defmacro with-let
   "Bind variables as with let, except that when used in a component
@@ -9,20 +8,3 @@
   destroyed."
   [bindings & body]
   `(ra/with-let ~bindings ~@body))
-
-(defn- source-info [env]
-  (when (:line env)
-    {:file (try
-             ((resolve 'cljs.analyzer.api/current-file))
-             (catch Exception _
-               ;; ana-api/current-file was added in 1.10.758
-               cljs.analyzer/*cljs-file*))
-     :line (:line env)
-     :column (:column env)}))
-
-(defmacro render
-  "Render function was moved to reagent.dom namespace in 1.0"
-  [& body]
-  (throw (ex-info "reagent.core/render function was moved to reagent.dom namespace in Reagent v1.0"
-                  (assoc (source-info &env) :tag :cljs/analysis-error)))
-  nil)

--- a/src/reagent/core.clj
+++ b/src/reagent/core.clj
@@ -1,5 +1,6 @@
 (ns reagent.core
-  (:require [reagent.ratom :as ra]))
+  (:require [reagent.ratom :as ra]
+            [cljs.analyzer.api :as ana-api]))
 
 (defmacro with-let
   "Bind variables as with let, except that when used in a component
@@ -8,3 +9,16 @@
   destroyed."
   [bindings & body]
   `(ra/with-let ~bindings ~@body))
+
+(defn- source-info [env]
+  (when (:line env)
+    {:file (ana-api/current-file)
+     :line (:line env)
+     :column (:column env)}))
+
+(defmacro render
+  "Render function was moved to reagent.dom namespace in 1.0"
+  [& body]
+  (throw (ex-info "reagent.core/render function was moved to reagent.dom namespace in Reagent v1.0"
+                  (assoc (source-info &env) :tag :cljs/analysis-error)))
+  nil)

--- a/src/reagent/core.clj
+++ b/src/reagent/core.clj
@@ -12,7 +12,11 @@
 
 (defn- source-info [env]
   (when (:line env)
-    {:file (ana-api/current-file)
+    {:file (try
+             (ana-api/current-file)
+             (catch Exception _
+               ;; ana-api/current-file was added in 1.10.758
+               cljs.analyzer/*cljs-file*))
      :line (:line env)
      :column (:column env)}))
 

--- a/src/reagent/core.clj
+++ b/src/reagent/core.clj
@@ -1,6 +1,6 @@
 (ns reagent.core
   (:require [reagent.ratom :as ra]
-            [cljs.analyzer.api :as ana-api]))
+            cljs.analyzer.api))
 
 (defmacro with-let
   "Bind variables as with let, except that when used in a component
@@ -13,7 +13,7 @@
 (defn- source-info [env]
   (when (:line env)
     {:file (try
-             (ana-api/current-file)
+             ((resolve 'cljs.analyzer.api/current-file))
              (catch Exception _
                ;; ana-api/current-file was added in 1.10.758
                cljs.analyzer/*cljs-file*))

--- a/src/reagent/core.cljs
+++ b/src/reagent/core.cljs
@@ -366,3 +366,9 @@
   (tmpl/set-default-compiler! (if (nil? compiler)
                                 tmpl/default-compiler*
                                 compiler)))
+
+(defn render
+  {:deprecated "0.10.0"}
+  [& _]
+  (throw (js/Error. "Reagent.core/render function was moved to reagent.dom namespace in Reagent v1.0."))
+  nil)


### PR DESCRIPTION
Fixes #501 

Not if it is a good idea to throw error tagged as `:cljs/analysis-error` but this would show quite clear error to the user and block the compilation.

In Figwheel:

```
Failed to compile build :client from ["demo"] in 0.592 seconds.
----  Could not Analyze  demo/reagentdemo/intro.cljs   line:66  column:3  ----

  reagent.core/render function was moved to reagent.dom namespace in Reagent v1.0

  65  (defn render-simple []
  66    (r/render
        ^--- reagent.core/render function was moved to reagent.dom namespace in Reagent v1.0
  67      [simple-component]
  68      (.-body js/document)))

----  Analysis Error : Please see demo/reagentdemo/intro.cljs  ----
```

In Shadow-cljs:

```
[:app] Build failure:
------ ERROR -------------------------------------------------------------------
 File: /home/juho/Source/metosin/x/src/cljs/frontend/main.cljs:207:3
--------------------------------------------------------------------------------
 204 |               {:use-fragment true})
 205 |   ...
 206 |   ...
 207 |   (r/render [error-boundary [main-view]]
---------^----------------------------------------------------------------------
Encountered error when macroexpanding reagent.core/render.
reagent.core/render function was moved to reagent.dom namespace in Reagent v1.0
--------------------------------------------------------------------------------
 208 |     (.getElementById js/document "app")))
 209 |
 210 | (main)
 211 |
--------------------------------------------------------------------------------
```