### PR TITLE
Update README to use correct namespace alias for call to dom-node

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ But you can still use them if you want to, either using `reagent.core/create-cla
   (with-meta plain-component
     {:component-did-mount
      (fn [this]
-       (reset! my-html (.-innerHTML (reagent/dom-node this))))}))
+       (reset! my-html (.-innerHTML (rd/dom-node this))))}))
 ```
 
 See the examples directory for more examples.


### PR DESCRIPTION
Looks like this got missed when the function moved between namespaces.