### PR TITLE
Support for css modules

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,3 +1,3 @@
 {:paths ["src" "test" "examples/todomvc/src" "examples/simple/src" "examples/geometry/src" "demo"]
  :deps {org.clojure/clojurescript {:mvn/version "1.10.753"}
-        doo {:mvn/version "0.1.11"}}}
+        doo/doo {:mvn/version "0.1.11"}}}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject reagent "1.0.0"
+(defproject reagent "1.0.0-bendyorke"
   :url "http://github.com/reagent-project/reagent"
   :license {:name "MIT"}
   :description "A simple ClojureScript interface to React"
@@ -10,7 +10,8 @@
                  [cljsjs/react-dom "17.0.1-0"]
                  [cljsjs/react-dom-server "17.0.1-0"]]
 
-  :plugins [[lein-cljsbuild "1.1.7"]
+  :plugins [[fipp "0.6.23"]
+            [lein-cljsbuild "1.1.7"]
             [lein-doo "0.1.11"]
             [lein-codox "0.10.7"]
             [lein-figwheel "0.5.19"]]

--- a/src/reagent/impl/protocols.cljs
+++ b/src/reagent/impl/protocols.cljs
@@ -2,6 +2,7 @@
 
 (defprotocol Compiler
   (get-id [this])
+  (parse-tag [this tag-name tag-value])
   (as-element [this x])
   (make-element [this argv component jsprops first-child]))
 

--- a/src/reagent/impl/template.cljs
+++ b/src/reagent/impl/template.cljs
@@ -252,7 +252,7 @@
         n (name tag)
         pos (.indexOf n ">")]
     (case pos
-      -1 (native-element (p/tarse-tag compiler n tag) v 1 compiler)
+      -1 (native-element (p/parse-tag compiler n tag) v 1 compiler)
       0 (assert (= ">" n) (util/hiccup-err v (comp/comp-name) "Invalid Hiccup tag"))
       ;; Support extended hiccup syntax, i.e :div.bar>a.foo
       ;; Apply metadata (e.g. :key) to the outermost element.


### PR DESCRIPTION
Hello reagent team - 

I recently extended the reagent compiler to include support for a custom tag parser to I could leverage css-modules in my own codebase. I have yet to open source anything, but I included my project code and pretty in depth documentation in a gist here: https://gist.github.com/bendyorke/09328798d468b0d1e7f730bba15e3236

Main idea is that by attaching a css module to the namespace you're in, you can then use namespace qualified keywords to locally scope css class names. i.e `:div.foo` becomes `<div class="foo">` and `::div.foo` becomes something akin to `<div class="__module_foo_abc123">`.

I'm not sure if this is something you're interested in merging in - either the custom tag parsing support or maybe the locally scoped css in general. It's easy enough for me to maintain separately, but css modules are a fantastic feature and namespace qualified keywords really make them incredibly easy to use. 