### PR TITLE
add reagent.dom to ns form for "Essential API" example

### DIFF
--- a/demo/reagentdemo/intro.cljs
+++ b/demo/reagentdemo/intro.cljs
@@ -110,6 +110,9 @@
 (def ns-src (s/syntaxed "(ns example
   (:require [reagent.core :as r]))"))
 
+  
+(def ns-src-with-rdom (s/syntaxed "(ns example
+  (:require [reagent.dom :as rdom]))"))
 
 (defn intro []
   (let [github {:href "https://github.com/reagent-project/reagent"}
@@ -234,7 +237,7 @@
    look like this:"]
 
    [demo-component {:src [:pre
-                          ns-src
+                          ns-src-with-rdom
                           (s/src-of [:simple-component :render-simple])]}]])
 
 (defn performance []


### PR DESCRIPTION
It looks like `reagent.dom` is not being included in the `ns` form under the "Essential API" section of the [intro page](http://reagent-project.github.io/).

I think this PR fixes the issue, but I'm not sure what other changes may need to be made in order to push out the fix to the page itself.