### PR TITLE
Add prefix to gensym call in create-compiler

### DIFF
--- a/src/reagent/impl/template.cljs
+++ b/src/reagent/impl/template.cljs
@@ -300,7 +300,7 @@
         :else x))
 
 (defn create-compiler [opts]
-  (let [id (gensym)
+  (let [id (gensym "reagent-compiler")
         fn-to-element (if (:function-components opts)
                         maybe-function-element
                         reag-element)


### PR DESCRIPTION
We had some tests in our application break after we updated reagent from 0.9. to 1.x which were completely separated from actual view code or anything related to reagent. The reason was the generated symbols with gensym in our code had shifted up by one. Taking a look in reagent code, I saw that all gensym calls except the one in create-compiler used a custom prefix. I think it would be a good idea to add one there too so that reagent code doesn't affect the output of gensym in the application code.