### PR TITLE
Fix #549: Add name property to classes and fns created by Reagent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+**[compare](https://github.com/reagent-project/reagent/compare/v1.1.0...master)**
+
+### Features and changes
+
+- Add name property to function and class components created by Reagent,
+this should add real function names to React component stacks on Error boundaries
+and errors on the console. ([#549](https://github.com/reagent-project/reagent/pull/549))
+
 ## 1.1.0 (2021-06-05)
 
 **[compare](https://github.com/reagent-project/reagent/compare/v1.0.0...v1.1.0)**

--- a/src/reagent/impl/component.cljs
+++ b/src/reagent/impl/component.cljs
@@ -329,7 +329,8 @@
       (set! (.-cljs$lang$ctorStr cmp) display-name)
       (set! (.-cljs$lang$ctorPrWriter cmp)
             (fn [this writer opt]
-              (cljs.core/-write writer display-name))))
+              (cljs.core/-write writer display-name)))
+      (js/Object.defineProperty cmp "name" #js {:value display-name :writable false}))
 
     (set! (.-cljs$lang$type cmp) true)
     (set! (.. cmp -prototype -constructor) cmp)
@@ -470,7 +471,9 @@
   ;; Or not currently - the memo wrap is required.
   (or (cached-react-class compiler tag)
       (let [f (fn [jsprops] (functional-render compiler jsprops))
-            _ (set! (.-displayName f) (util/fun-name tag))
+            display-name (util/fun-name tag)
+            _ (set! (.-displayName f) display-name)
+            _ (js/Object.defineProperty f "name" #js {:value display-name :writable false})
             f (react/memo f functional-render-memo-fn)]
         (cache-react-class compiler tag f)
         f)))

--- a/test/reagenttest/testreagent.cljs
+++ b/test/reagenttest/testreagent.cljs
@@ -1236,12 +1236,10 @@
                  (r/flush)
                  (is (= "Test error" (.-message @error)))
                  (is (re-find #"Something went wrong\." (.-innerHTML div)))
-                 ;; FIXME: React.memo messes this up
-                 #_
                  (if (dev?)
-                   (is (re-find #"\n    in reagenttest.testreagent.comp1 \(created by reagenttest.testreagent.comp2\)\n    in reagenttest.testreagent.comp2 \(created by reagent[0-9]+\)\n    in reagent[0-9]+ \(created by reagenttest.testreagent.error_boundary\)\n    in reagenttest.testreagent.error_boundary"
+                   (is (re-find #"^\n    at reagenttest.testreagent.comp1 \([^)]*\)\n    at reagenttest.testreagent.comp2 \([^)]*\)\n    at reagent[0-9]+ \([^)]*\)\n    at reagenttest.testreagent.error_boundary \([^)]*\)$"
                                 (.-componentStack ^js @info)))
-                   (is (re-find #"\n    in .+\n    in .+\n    in reagent[0-9]+\n    in .+"
+                   (is (re-find #"^\n    at reagent[0-9]+. \([^)]*\)\n    at reagent[0-9]+ \([^)]*\)\n    at reagent[0-9]+ \([^)]*\)\n    at .+ \([^)]*\)$"
                                 (.-componentStack ^js @info))))))))))))
 
 (deftest test-dom-node


### PR DESCRIPTION
React componentStack information at least will use these names.