### PR TITLE
Add ^ to metadata on reagent.core/render

### DIFF
--- a/src/reagent/core.cljs
+++ b/src/reagent/core.cljs
@@ -368,7 +368,7 @@
                                 compiler)))
 
 (defn render
-  {:deprecated "0.10.0"
-   :superseded-by "reagent.dom/render"}
+  ^{:deprecated "0.10.0"
+    :superseded-by "reagent.dom/render"}
   [& _]
   (throw (js/Error. "Reagent.core/render function was moved to reagent.dom namespace in Reagent v1.0.")))


### PR DESCRIPTION
Previously builds would get a warning about unreachable code. Adding the ^ marks the deprecated map as metadata and removes the warning.

Fixes https://github.com/reagent-project/reagent/issues/533

```
[:app] Compiling ...
------ WARNING #1 -  -----------------------------------------------------------
 File: ~/.m2/repository/reagent/reagent/1.0.0/reagent-1.0.0.jar!/reagent/core.cljs:370
--------------------------------------------------------------------------------
 367 |                                 tmpl/default-compiler*
 368 |                                 compiler)))
 369 | 
 370 | (defn render
--------------------------------------------------------------------------------
 unreachable code
--------------------------------------------------------------------------------
 371 |   {:deprecated "0.10.0"}
 372 |   [& _]
 373 |   (throw (js/Error. "Reagent.core/render function was moved to reagent.dom namespace in Reagent v1.0."))
 374 |   nil)
--------------------------------------------------------------------------------
```