### PR TITLE
Refactor Reaction type to clarify when things “change”

### DIFF
--- a/doc/WhenDoComponentsUpdate.md
+++ b/doc/WhenDoComponentsUpdate.md
@@ -174,15 +174,21 @@ For `props`,  `=` is used to determine if a new value have changed with regard t
 
 For ratoms, `identical?` is used (on the value inside the ratom) to determine if a new value has changed with regard to an old value. 
 
+For reactions (cursors/tracks), `=` is used to determine if a new value has changed with regard to an old value.
+
 So, it is only when values are deemed to have "changed", that a re-run is triggered, but the inputs use different definitions of "changed".  This can be confusing. 
 
 The `identical?` version is very fast. It is just a single reference check.
 
 The `=` version is more accurate, more intuitive, but potentially more expensive. Although, as I'm writing this I notice that `=` uses `identical?` [when it can](https://github.com/clojure/clojurescript/blob/1b7390450243693d0b24e8d3ad085c6da4eef204/src/main/cljs/cljs/core.cljs#L1108-L1124).
 
-**Update:**
+**Technical details**:
 
-> As of Reagent 0.6.0, ratoms use `=` (instead of `identical?`) is to determine if a new value is different to an old value. So, `ratoms` and `props` now have the same `changed?` semantics. 
+> A reagent component wraps a `Reaction` object around its render function, calling `add-watch` on all its dependent ratoms and Reactions.
+> A Reaction object ignores any watch notification if its value is `identical?` to its old value.
+> But a Reaction object itself will not send a watch notification to other Reactions if its own new value is strictly `=` to its old value.
+>
+> Thus, for whatever reason, a Reaction uses `identical?` on inbound values, but `=` on outbound values.
 
 ### Efficient Re-renders
 

--- a/src/reagent/ratom.cljs
+++ b/src/reagent/ratom.cljs
@@ -391,14 +391,13 @@
       (-deref this)))
 
   (_handle-change [this sender oldval newval]
-    (when-not (or (identical? oldval newval)
-                  dirty?)
-      (if (nil? auto-run)
-        (do
-          (set! dirty? true)
-          (rea-enqueue this))
-        (if (true? auto-run)
-          (._run this false)
+    (when-not dirty?
+      ;; Use `identical?` to determine equality from input changes.
+      (when-not (identical? oldval newval)
+        (case auto-run
+          nil (do (set! dirty? true)
+                  (rea-enqueue this))
+          true (._run this false)
           (auto-run this)))))
 
   (_update-watching [this derefed]

--- a/src/reagent/ratom.cljs
+++ b/src/reagent/ratom.cljs
@@ -457,18 +457,17 @@
     (when-some [e caught]
       (throw e))
     (let [non-reactive (nil? *ratom-context*)]
-      (when non-reactive
-        (flush!))
-      (if (and non-reactive (nil? auto-run))
-        (when dirty?
+      (if non-reactive
+        (flush!)
+        (notify-deref-watcher! this))
+      (when dirty?
+        (if (and non-reactive (nil? auto-run))
+          ;; like "_run" but skips deref-capture
           (let [oldstate state]
             (set! state (f))
             (when-not (or (nil? watches) (= oldstate state))
-              (notify-w this oldstate state))))
-        (do
-          (notify-deref-watcher! this)
-          (when dirty?
-            (._run this false)))))
+              (notify-w this oldstate state)))
+          (._run this false))))
     state)
 
   IDisposable

--- a/src/reagent/ratom.cljs
+++ b/src/reagent/ratom.cljs
@@ -456,18 +456,17 @@
   (-deref [this]
     (when-some [e caught]
       (throw e))
-    (let [non-reactive (nil? *ratom-context*)]
-      (if non-reactive
-        (flush!)
-        (notify-deref-watcher! this))
-      (when dirty?
-        (if (and non-reactive (nil? auto-run))
-          ;; like "_run" but skips deref-capture
-          (let [oldstate state]
-            (set! state (f))
-            (when-not (or (nil? watches) (= oldstate state))
-              (notify-w this oldstate state)))
-          (._run this false))))
+    (if (reactive?)
+      (notify-deref-watcher! this)
+      (flush!))
+    (when dirty?
+      (if (or (reactive?) auto-run)
+        (._run this false)
+        ;; like "_run" but skips deref-capture
+        (let [oldstate state]
+          (set! state (f))
+          (when-not (or (nil? watches) (= oldstate state))
+            (notify-w this oldstate state)))))
     state)
 
   IDisposable

--- a/src/reagent/ratom.cljs
+++ b/src/reagent/ratom.cljs
@@ -459,8 +459,8 @@
   (-deref [this]
     (when-some [e caught]
       (throw e))
-    (if (reactive?)
-      (notify-deref-watcher! this)
+    (notify-deref-watcher! this)
+    (when-not (reactive?)
       (flush!))
     (when dirty?
       (if (or (reactive?) auto-run)


### PR DESCRIPTION
After having trouble understanding all the branches inside the Reaction Deref function, I pulled the `notify-deref-watcher!` before the dirty check, so we can combine both dirty checks.  Please verify that this is equivalent and easier to follow!