### PR TITLE
Precisely clarify when Reactions send/receive changes

### DIFF
--- a/doc/WhenDoComponentsUpdate.md
+++ b/doc/WhenDoComponentsUpdate.md
@@ -174,15 +174,21 @@ For `props`,  `=` is used to determine if a new value have changed with regard t
 
 For ratoms, `identical?` is used (on the value inside the ratom) to determine if a new value has changed with regard to an old value. 
 
+For reactions (cursors/tracks), `=` is used to determine if a new value has changed with regard to an old value.
+
 So, it is only when values are deemed to have "changed", that a re-run is triggered, but the inputs use different definitions of "changed".  This can be confusing. 
 
 The `identical?` version is very fast. It is just a single reference check.
 
 The `=` version is more accurate, more intuitive, but potentially more expensive. Although, as I'm writing this I notice that `=` uses `identical?` [when it can](https://github.com/clojure/clojurescript/blob/1b7390450243693d0b24e8d3ad085c6da4eef204/src/main/cljs/cljs/core.cljs#L1108-L1124).
 
-**Update:**
+**Technical details**:
 
-> As of Reagent 0.6.0, ratoms use `=` (instead of `identical?`) is to determine if a new value is different to an old value. So, `ratoms` and `props` now have the same `changed?` semantics. 
+> A reagent component wraps a `Reaction` object around its render function, calling `add-watch` on all its dependent ratoms and Reactions.
+> A Reaction object ignores any watch notification if its value is `identical?` to its old value.
+> But a Reaction object itself will not send a watch notification to other Reactions if its own new value is strictly `=` to its old value.
+>
+> Thus, for whatever reason, a Reaction uses `identical?` on inbound values, but `=` on outbound values.
 
 ### Efficient Re-renders
 


### PR DESCRIPTION
Fixes #574 

I did a deep study on how the Reaction object sends and receives changes.  It was hard to discern the meaning of the accreted branches of logic, so I hope this refactor clarifies how everything is actually working.  No behavior changes were made.

1. Corrected the “Changed?” docs (ratoms are not `=` tested as was indicated).
2. Isolate the `dirty?` conditions so it’s easier to see what it’s preventing.
3. Isolate the `identical?` and `=` to clarify the change detections.
4. Added a `_set-state` to Reaction so the change detection from `-deref` and `_run` can be shared.

<img width="1589" alt="CleanShot 2022-08-29 at 21 24 14@2x" src="https://user-images.githubusercontent.com/116838/187456101-dcd886a8-f0f7-4f0f-90c8-cd59f7763e87.png">
