### PR TITLE
Add documentation/example for SSR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ node_modules
 junit
 .shadow-cljs
 coverage/
+
+.clj-kondo/
+.cpcache/
+.lsp/.cache

--- a/doc/ReactFeatures.md
+++ b/doc/ReactFeatures.md
@@ -228,6 +228,13 @@ as properties into the React function component.
     (react-dom/createPortal (r/as-element [:div "foo"]) el)))
 ```
 
+## [Server-Side Rendering (SSR)](https://react.dev/reference/react-dom/server/renderToString)
+
+```cljs
+(reagent.dom.server/render-to-string
+   (reagent.core/as-element [main-component]))
+```
+
 ## [Hydrate](https://reactjs.org/docs/react-dom.html#hydrate)
 
 ```cljs


### PR DESCRIPTION
A simple code example of server-side rendering with `reagent.dom.server/render-to-string`

Related #302