### PR TITLE
Add a basic clj-kondo config for library consumers

### DIFF
--- a/src/clj-kondo/clj-kondo.exports/reagent/reagent/config.edn
+++ b/src/clj-kondo/clj-kondo.exports/reagent/reagent/config.edn
@@ -1,0 +1,1 @@
+{:lint-as {reagent.core/with-let clojure.core/let}}


### PR DESCRIPTION
Address part of what is described in

- https://github.com/reagent-project/reagent/issues/610

I think that this small contribution

- makes it easier for "newbies" to use reagent in a kondo-powered IDE (clojure-lsp is powered by kondo)
- facilitates and avoids explicit kondo configuration for simple use-cases

I plan to do a full implementation (via hooks, supporting finally) soon.

