### PR TITLE
Only allow UnsafeHtml values for :dangerouslySetInnerHTML

### DIFF
--- a/src/reagent/core.cljs
+++ b/src/reagent/core.cljs
@@ -372,3 +372,13 @@
    :superseded-by "reagent.dom/render"}
   [& _]
   (throw (js/Error. "Reagent.core/render function was moved to reagent.dom namespace in Reagent v1.0.")))
+
+(defn unsafe-html
+  "Create a tagged value for use with :dangerouslySetInnerHTML. Reagent doesn't
+  allow other values to be used with the property, to ensure data from external
+  sources (using EDN or Transit) can't be used to accidentally create arbitrary
+  HTML.
+
+  See doc/Security.md"
+  [s]
+  (tmpl/UnsafeHTML. s))

--- a/test/reagenttest/testreagent.cljs
+++ b/test/reagenttest/testreagent.cljs
@@ -308,7 +308,7 @@
          (as-string [:div.bar [:p "foo"]])))
   (is (= "<div class=\"bar\"><p>foobar</p></div>"
          (as-string [:div.bar {:dangerously-set-inner-HTML
-                               {:__html "<p>foobar</p>"}}]))))
+                               (r/unsafe-html "<p>foobar</p>")}]))))
 
 (u/deftest ^:dom test-return-class
   (let [ran (atom 0)
@@ -1525,3 +1525,12 @@
                                     16))))
                [really-simple]]
               u/fn-compiler)))))))
+
+(u/deftest test-unsafe-html
+  (testing "Regular value is ignored"
+    (is (= "<div></div>"
+           (as-string (r/as-element [:div {:dangerouslySetInnerHTML {:__html "<img/>"}}])))))
+
+  (testing "Tagged value is allowed"
+    (is (= "<div><img/></div>"
+           (as-string (r/as-element [:div {:dangerouslySetInnerHTML (r/unsafe-html "<img/>")}]))))))


### PR DESCRIPTION
See https://github.com/reagent-project/reagent/blob/master/doc/Security.md

This does prevent ONE case where EDN/Transit could be used to create arbitrary HTML elements without going through React.

The `convert-props` is on a very often called code-path, but I hope one JS property check is not too bad. The Clojure map to JS object conversion is already quite slow.