### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To use Reagent in an existing project you add this to your dependencies in `proj
 And provide React using either npm (when using e.g. [Shadow-cljs](https://shadow-cljs.github.io/docs/UsersGuide.html))
 
 ```
-npm i react react-dom@17.0.2 react@17.0.2
+npm i react react-dom@18.3.1 react@18.3.1
 ```
 
 or by adding [Cljsjs](http://cljsjs.github.io/) React packages to your project:
@@ -51,8 +51,8 @@ or by adding [Cljsjs](http://cljsjs.github.io/) React packages to your project:
 [cljsjs/react-dom "17.0.2-0"]
 ```
 
-Note: Reagent is tested against React 17, but should be compatible with older
-versions. It is not compatible with newer versions
+Note: Reagent is tested against React 17, but should be compatible with other
+versions. It is not compatible with React 19
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To use Reagent in an existing project you add this to your dependencies in `proj
 And provide React using either npm (when using e.g. [Shadow-cljs](https://shadow-cljs.github.io/docs/UsersGuide.html))
 
 ```
-npm i react react-dom
+npm i react react-dom@17.0.2 react@17.0.2
 ```
 
 or by adding [Cljsjs](http://cljsjs.github.io/) React packages to your project:
@@ -51,8 +51,8 @@ or by adding [Cljsjs](http://cljsjs.github.io/) React packages to your project:
 [cljsjs/react-dom "17.0.2-0"]
 ```
 
-Note: Reagent is tested against React 17, but should be compatible with other
-versions.
+Note: Reagent is tested against React 17, but should be compatible with older
+versions. It is not compatible with newer versions
 
 ## Examples
 


### PR DESCRIPTION
Specifically reagent.dom/render function throws an error on newer versions of react, and likely for other functions as well. Updating readme to specify that you need to npm install specific versions of react and react-dom for shadow-cljs builds.