### PR TITLE
Fix geometry example build

### DIFF
--- a/examples/geometry/shadow-cljs.edn
+++ b/examples/geometry/shadow-cljs.edn
@@ -6,5 +6,5 @@
         :asset-path "/js"
         :devtools {:after-load geometry.core/run}
         :modules {:main {:entries [geometry.core]
-                         :init-fn geometry.core}}}}
+                         :init-fn geometry.core/run}}}}
  :dependencies [[reagent "1.2.0"]]}


### PR DESCRIPTION
Updated the Shadow CLJS :init-fn to refer to the `run` function.

Before this change, `npm shadow-cljs watch :app` failed with:

```
[:app] Build failure:
Invalid configuration
-- Spec failed --------------------

  {:target ...,
   :output-dir ...,
   :asset-path ...,
   :devtools ...,
   :modules {:main {:entries ..., :init-fn geometry.core}},
                                           ^^^^^^^^^^^^^
   :build-id ...}

should satisfy

  unquoted-qualified-symbol?
```