### PR TITLE
Try using flushSync when flushing Reagent render queue

### DIFF
--- a/src/reagent/dom/client.cljs
+++ b/src/reagent/dom/client.cljs
@@ -1,6 +1,7 @@
 (ns reagent.dom.client
   (:require ["react" :as react]
             ["react-dom/client" :as react-dom-client]
+            ["react-dom" :as react-dom]
             [reagent.impl.batching :as batch]
             [reagent.impl.protocols :as p]
             [reagent.impl.template :as tmpl]
@@ -52,6 +53,7 @@
   ([^js root el]
    (render root el tmpl/*current-default-compiler*))
   ([^js root el compiler]
+   (set! batch/react-flush react-dom/flushSync)
    (let [comp (fn [] (p/as-element compiler el))
          js-props #js {}]
      (set! (.-comp js-props) comp)
@@ -62,6 +64,7 @@
    (hydrate-root container el nil))
   ([container el {:keys [compiler on-recoverable-error identifier-prefix]
                   :or {compiler tmpl/*current-default-compiler*}}]
+   (set! batch/react-flush react-dom/flushSync)
    (let [js-props #js {}
          comp (fn [] (p/as-element compiler el))]
      (set! (.-comp js-props) comp)


### PR DESCRIPTION
This will avoid double queuing when Reagent has already queued components to render due to ratom changes.