### PR TITLE
Add the :strict? option to with-render*

### DIFF
--- a/src/reagent/dom/client.cljs
+++ b/src/reagent/dom/client.cljs
@@ -51,13 +51,19 @@
   "Render the given Reagent element (i.e. Hiccup data)
   into a given React root."
   ([^js root el]
-   (render root el tmpl/*current-default-compiler*))
+   (render root el nil))
   ([^js root el compiler]
+   (render root el compiler false))
+  ([^js root el compiler strict-mode?]
    (set! batch/react-flush react-dom/flushSync)
-   (let [comp (fn [] (p/as-element compiler el))
-         js-props #js {}]
-     (set! (.-comp js-props) comp)
-     (.render root (react/createElement reagent-root js-props)))))
+   (let [eff-compiler (or compiler tmpl/*current-default-compiler*)
+         comp (fn [] (p/as-element eff-compiler el))
+         js-props #js {:comp comp}
+         rg-root-el (react/createElement reagent-root js-props)]
+     (.render root
+              (if-not strict-mode?
+                rg-root-el
+                (react/createElement react/StrictMode #js {} rg-root-el))))))
 
 (defn hydrate-root
   ([container el]

--- a/test/reagenttest/utils.cljs
+++ b/test/reagenttest/utils.cljs
@@ -126,6 +126,7 @@
          callback (fn []
                     (p/resolve! first-render))
          compiler (:compiler options)
+         strict? (:strict? options)
          restore-error-handlers (when (:capture-errors options)
                                   (init-capture))
          root (rdomc/create-root div)
@@ -133,9 +134,7 @@
          ;; with-render body.
          render-error (atom nil)]
      (-> (act* (fn []
-                 (if compiler
-                   (rdomc/render root comp compiler)
-                   (rdomc/render root comp))))
+                 (rdomc/render root comp compiler strict?)))
          ;; The callback is called even if render throws an error,
          ;; so this is always resolved.
          (p/then (fn []


### PR DESCRIPTION
Setting the `:strict?` option causes the react/StrictMode component to be inserted at the top level, wrapping Reagent root.

This is a prerequisite for fixing #634, which I am going to address next.